### PR TITLE
Fix stub test title

### DIFF
--- a/file.management.stub.spec.js
+++ b/file.management.stub.spec.js
@@ -18,7 +18,7 @@ describe("File Management Stub", () => {
     expect(writeStub.callCount).to.equal(1);
   });
 
-  it("Should create a file", () => {
+  it("Should throw an exception if file already exists", () => {
     const writeStub = sinon.stub(fs, "writeFileSync");
     writeStub.throws(new Error("FAIL"));
     const fileManagement = proxyquire("./file.management", { fs });

--- a/file.management.stub.spec.js
+++ b/file.management.stub.spec.js
@@ -18,7 +18,7 @@ describe("File Management Stub", () => {
     expect(writeStub.callCount).to.equal(1);
   });
 
-  it("Should throw an exception if file already exists", () => {
+  it("Should throw an exception when the file already exists", () => {
     const writeStub = sinon.stub(fs, "writeFileSync");
     writeStub.throws(new Error("FAIL"));
     const fileManagement = proxyquire("./file.management", { fs });


### PR DESCRIPTION
In the course video, the title of this second test is `Should throw an exception if file already exists` but in the repo, it has the same name as the first test which confused me and can do the same with other students. I fixed it with the name you used on the course.

By the way, I am enjoying the course, thank you for doing it!